### PR TITLE
Add possessive replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demo.py
 live.py
 mmmc.py
 *__pycache__
+account.info

--- a/xbar.py
+++ b/xbar.py
@@ -75,8 +75,10 @@ VP_COMP -> DP
 
 DP -> DP_SPEC? D'
 D' -> D DP_COMP?
-DP_SPEC -> ENTITY_person
-D -> ENTITY_possessive | FUNC_determiner
+DP_SPEC -> ENTITY_noun | ENTITY_person
+D -> ENTITY_possessive
+    | ENTITY_num
+    | FUNC_determiner
 DP_COMP -> NP
 
 NP -> N'
@@ -94,6 +96,7 @@ parserDict = parserOfRules(simple_rules)
 # ic(parserDict)
 
 import json
+import re
 from requests import post
 
 with open("./account.info", "r", encoding="utf-8") as f:
@@ -103,12 +106,16 @@ url = "https://nlu.droidtown.co/Articut/API/"
 payload = {
     "username": accountDICT["username"],
     "api_key": accountDICT["apikey"],
-    "input_str": "The dog is my friend."
+    "input_str": "My brother is John's classmate."
 }
 
 resultDICT = post(url, json=payload).json()
+response = ''.join(resultDICT["result_pos"]) 
+pat = re.compile("<ENTITY_possessive>([^<]+)('[Ss])</ENTITY_possessive>")
+response = re.sub(pat, lambda m: "<ENTITY_noun>{}</ENTITY_noun><FUNC_determiner>{}</FUNC_determiner>".format(m.group(1), m.group(2)), response)
 #print(resultDICT)
-inputSTR = "".join(resultDICT["result_pos"]).replace(" ","").replace(".", "")
+inputSTR = response.replace(" ","").replace(".", "")
+#print(inputSTR)
 print(payload["input_str"] + "\n")
 
 #t1 = "<ENTITY_pronoun>He</ENTITY_pronoun><AUX>is</AUX><MODIFIER>so</MODIFIER><MODIFIER>envious</MODIFIER><FUNC_inner>of</FUNC_inner><ENTITY_possessive>his</ENTITY_possessive><ENTITY_pronoun>sister</ENTITY_pronoun>"
@@ -118,7 +125,6 @@ test_VP = parserDict.ruleParser['VP']
 test_VP.parse(inputSTR).pprint()
 
 #ic(parserDict.ruleParser['VP'].parse(t2))
-=======
 # Degree  -> MODIFIER>(very|so|quite)</MODIFIER>
 
 parserDict = parserOfRules(new_rules)

--- a/xbar.py
+++ b/xbar.py
@@ -75,7 +75,7 @@ VP_COMP -> DP
 
 DP -> DP_SPEC? D'
 D' -> D DP_COMP?
-DP_SPEC -> ENTITY_person | DP
+DP_SPEC -> ENTITY_person
 D -> ENTITY_possessive | FUNC_determiner
 DP_COMP -> NP
 
@@ -93,10 +93,30 @@ PP_COMP -> NP
 parserDict = parserOfRules(simple_rules)
 # ic(parserDict)
 
-t1 = "<ENTITY_pronoun>He</ENTITY_pronoun><AUX>is</AUX><MODIFIER>so</MODIFIER><MODIFIER>envious</MODIFIER><FUNC_inner>of</FUNC_inner><ENTITY_possessive>his</ENTITY_possessive><ENTITY_pronoun>sister</ENTITY_pronoun>"
-t2 = "<FUNC_determiner>The</FUNC_determiner><ENTITY_noun>dog</ENTITY_noun><AUX>is</AUX><ENTITY_possessive>my</ENTITY_possessive><ENTITY_possessive>sister's</ENTITY_possessive><ENTITY_nouny>classmate</ENTITY_nouny><AUX>is</AUX><ENTITY_noun>dog</ENTITY_noun>"
+import json
+from requests import post
+
+with open("./account.info", "r", encoding="utf-8") as f:
+    accountDICT = json.load(f)
+
+url = "https://nlu.droidtown.co/Articut/API/"
+payload = {
+    "username": accountDICT["username"],
+    "api_key": accountDICT["apikey"],
+    "input_str": "The dog is my friend."
+}
+
+resultDICT = post(url, json=payload).json()
+#print(resultDICT)
+inputSTR = "".join(resultDICT["result_pos"]).replace(" ","").replace(".", "")
+print(payload["input_str"] + "\n")
+
+#t1 = "<ENTITY_pronoun>He</ENTITY_pronoun><AUX>is</AUX><MODIFIER>so</MODIFIER><MODIFIER>envious</MODIFIER><FUNC_inner>of</FUNC_inner><ENTITY_possessive>his</ENTITY_possessive><ENTITY_pronoun>sister</ENTITY_pronoun>"
+#t2 = "<FUNC_determiner>The</FUNC_determiner><ENTITY_noun>dog</ENTITY_noun><AUX>is</AUX><ENTITY_possessive>my</ENTITY_possessive><ENTITY_noun>dog</ENTITY_noun>"
+
 test_VP = parserDict.ruleParser['VP']
-test_VP.parse(t2).pprint()
+test_VP.parse(inputSTR).pprint()
+
 #ic(parserDict.ruleParser['VP'].parse(t2))
 =======
 # Degree  -> MODIFIER>(very|so|quite)</MODIFIER>


### PR DESCRIPTION
I implemented re.sub() to modify the articut result, ensuring that the apostrophe_s stays in the DP_head position.